### PR TITLE
Fix for building x86_64 target

### DIFF
--- a/Sources/CMarauders/include/CMarauders.h
+++ b/Sources/CMarauders/include/CMarauders.h
@@ -8,7 +8,6 @@
 
 #include "../xnu/bsd/sys/proc_info.h"
 #include "../xnu/bsd/sys/sys_domain.h"
-#include "../xnu/bsd/sys/pipe.h"
 #include "../xnu/bsd/sys/ev.h"
 #include "../xnu/bsd/net/route.h"
 #include "../xpc/xpc_base.h"
@@ -19,6 +18,7 @@
 
 #include "../xpc/xpc_pipe.h"
 #include "../xnu/bsd/net/net_kev.h"
+#include "../xnu/bsd/sys/pipe.h"
 #include "../xnu/bsd/sys/kern_event.h"
 #include "../dyld/src/dyld_process_info_internal.h"
 #include "../xnu/libsyscall/wrappers/libproc/libproc.h"


### PR DESCRIPTION
Just reveals `xnu/bsd/sys/pipe.h` to both targets (specifically, the `PIPE_SEL` def is missing in `Marauders/Sources/Marauders/ProcessMonitor/ProcessMonitor.FileDescription.swift` when trying to compile without it)